### PR TITLE
Add FastAPI Whisper streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# C0D3KS2
+# FastAPI Whisper Transcription Example
+
+This project demonstrates a minimal FastAPI backend that captures microphone audio, transcribes it with OpenAI Whisper, and streams the transcription to a browser via WebSockets.
+
+## Requirements
+
+- Python 3.9+
+- `fastapi`, `uvicorn`, `pyaudio`, `openai`
+
+Install dependencies:
+
+```bash
+pip install fastapi uvicorn pyaudio openai
+```
+
+Set your OpenAI API key in the environment:
+
+```bash
+export OPENAI_API_KEY=your_key_here
+```
+
+## Running the backend
+
+Start the FastAPI app with uvicorn:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running the frontend
+
+Serve the `static/` directory using any simple HTTP server. For example:
+
+```bash
+python -m http.server --directory static 8000
+```
+
+Then open `http://localhost:8000` in your browser. The page will connect to the WebSocket endpoint and display live transcription results.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,104 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+import asyncio
+import pyaudio
+import wave
+import time
+import os
+import tempfile
+import openai
+from typing import List
+
+# Placeholder for your OpenAI API key
+openai.api_key = os.getenv('OPENAI_API_KEY', 'YOUR_OPENAI_API_KEY')
+
+app = FastAPI()
+
+class ConnectionManager:
+    """Manages active WebSocket connections."""
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: str):
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(message)
+            except WebSocketDisconnect:
+                self.disconnect(connection)
+
+manager = ConnectionManager()
+
+# Audio recording parameters
+CHUNK = 1024
+FORMAT = pyaudio.paInt16
+CHANNELS = 1
+RATE = 16000
+CHUNK_SECONDS = 5  # duration of each audio chunk in seconds
+
+async def transcribe_audio(audio_bytes: bytes) -> str:
+    """Send audio bytes to OpenAI Whisper API and return transcription."""
+    # Write bytes to temporary WAV file
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        with wave.open(tmp.name, 'wb') as wf:
+            wf.setnchannels(CHANNELS)
+            wf.setsampwidth(pyaudio.get_sample_size(FORMAT))
+            wf.setframerate(RATE)
+            wf.writeframes(audio_bytes)
+        tmp.seek(0)
+        audio_file = open(tmp.name, 'rb')
+        try:
+            result = openai.Audio.transcribe("whisper-1", audio_file)
+            text = result.get('text', '')
+        finally:
+            audio_file.close()
+        os.unlink(tmp.name)
+    return text
+
+async def audio_loop():
+    """Continuously capture microphone audio, transcribe, and broadcast."""
+    p = pyaudio.PyAudio()
+    stream = p.open(format=FORMAT,
+                    channels=CHANNELS,
+                    rate=RATE,
+                    input=True,
+                    frames_per_buffer=CHUNK)
+    frames = []
+    start_time = time.time()
+
+    while True:
+        data = stream.read(CHUNK, exception_on_overflow=False)
+        frames.append(data)
+        if time.time() - start_time >= CHUNK_SECONDS:
+            audio_data = b''.join(frames)
+            frames = []
+            start_time = time.time()
+            text = await transcribe_audio(audio_data)
+            if text:
+                await manager.broadcast(text)
+
+@app.on_event("startup")
+async def startup_event():
+    # Start audio capturing loop as background task
+    asyncio.create_task(audio_loop())
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()  # Keep connection open
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+
+@app.get("/")
+async def get_index():
+    with open(os.path.join('static', 'index.html')) as f:
+        return HTMLResponse(f.read())

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Live Transcription</title>
+</head>
+<body>
+    <h1>Live Whisper Transcription</h1>
+    <pre id="output"></pre>
+
+    <script>
+        const output = document.getElementById('output');
+        const ws = new WebSocket(`ws://${location.host}/ws`);
+        ws.onmessage = (event) => {
+            output.textContent += event.data + '\n';
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement FastAPI backend with PyAudio capture
- send audio chunks to Whisper API and stream transcription via WebSockets
- provide simple HTML page to display transcribed text
- update README with instructions for running backend and frontend

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865ee5b35bc8330962a56601c631d6d